### PR TITLE
Add top level assessment entity

### DIFF
--- a/db/migrations/1623852472151-ReferenceData.ts
+++ b/db/migrations/1623852472151-ReferenceData.ts
@@ -86,6 +86,33 @@ export class ReferenceData1623852472151 implements MigrationInterface {
             ),
             FOREIGN KEY(group_uuid) REFERENCES grouping(group_uuid));
         `)
+    await queryRunner.query(`
+            CREATE TABLE IF NOT EXISTS question_dependency(
+            dependency_id           SERIAL      PRIMARY KEY,
+            subject_question_uuid   UUID        NOT NULL,
+            trigger_question_uuid   UUID        NOT NULL,
+            trigger_answer_value    TEXT        NOT NULL,
+            dependency_start        TIMESTAMP   NOT NULL,
+            dependency_end          TIMESTAMP,
+            display_inline          BOOLEAN     NOT NULL);
+        `)
+    await queryRunner.query(`
+            CREATE TABLE IF NOT EXISTS assessment_schema(
+            assessment_schema_id                SERIAL      PRIMARY KEY,
+            assessment_schema_uuid              UUID        NOT NULL unique,
+            assessment_schema_code              TEXT        NOT NULL,
+            oasys_assessment_type               TEXT,
+            oasys_create_assessment_at          TEXT,
+            assessment_name                     TEXT);
+        `)
+    await queryRunner.query(`
+            CREATE TABLE IF NOT EXISTS assessment_schema_groups(
+            assessment_schema_group_id  SERIAL      PRIMARY KEY,
+            assessment_schema_uuid      UUID        NOT NULL,
+            group_uuid                  UUID        NOT NULL,
+            FOREIGN KEY (assessment_schema_uuid) REFERENCES assessment_schema (assessment_schema_uuid),
+            FOREIGN KEY (group_uuid) REFERENCES grouping (group_uuid));
+        `)
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {}

--- a/server/app.ts
+++ b/server/app.ts
@@ -23,6 +23,8 @@ import Question from './repositories/entities/question'
 import QuestionGroup from './repositories/entities/questionGroup'
 import Grouping from './repositories/entities/grouping'
 import AnswerGroup from './repositories/entities/answerGroup'
+import QuestionDependency from './repositories/entities/questionDependency'
+import AssessmentSchemaGroups from './repositories/entities/assessmentSchemaGroup'
 
 export default function createApplication(userService: UserService, databaseConnection: Connection): Application {
   const app = express()
@@ -44,11 +46,22 @@ export default function createApplication(userService: UserService, databaseConn
   const questionGroupRepository = databaseConnection.getRepository(QuestionGroup)
   const groupingRepository = databaseConnection.getRepository(Grouping)
   const answerGroupRepository = databaseConnection.getRepository(AnswerGroup)
+  const questionDependencyRepository = databaseConnection.getRepository(QuestionDependency)
+  const assessmentTypeRepository = databaseConnection.getRepository(AssessmentSchemaGroups)
 
   app.use('/', indexRoutes(standardRouter(userService)))
   app.use(
     '/',
-    indexRoutes(questionRouter(questionRepository, questionGroupRepository, groupingRepository, answerGroupRepository))
+    indexRoutes(
+      questionRouter(
+        questionRepository,
+        questionGroupRepository,
+        groupingRepository,
+        answerGroupRepository,
+        questionDependencyRepository,
+        assessmentTypeRepository
+      )
+    )
   )
 
   app.use((req, res, next) => next(createError(404, 'Not found')))

--- a/server/repositories/db.ts
+++ b/server/repositories/db.ts
@@ -6,6 +6,9 @@ import Question from './entities/question'
 import QuestionGroup from './entities/questionGroup'
 import Answer from './entities/answer'
 import AnswerGroup from './entities/answerGroup'
+import QuestionDependency from './entities/questionDependency'
+import AssessmentSchema from './entities/assessmentSchema'
+import AssessmentSchemaGroups from './entities/assessmentSchemaGroup'
 
 type ConnectionResult = [Error?, Connection?]
 
@@ -17,7 +20,16 @@ const connectionOptions: ConnectionOptions = {
   username: String(process.env.DATABASE_USER),
   password: String(process.env.DATABASE_PASSWORD),
   database: String(process.env.DATABASE_NAME),
-  entities: [Grouping, QuestionGroup, Question, Answer, AnswerGroup],
+  entities: [
+    Grouping,
+    QuestionGroup,
+    Question,
+    Answer,
+    AnswerGroup,
+    QuestionDependency,
+    AssessmentSchema,
+    AssessmentSchemaGroups,
+  ],
   migrationsRun: Boolean(process.env.DATABASE_RUN_MIGRATIONS),
   migrations: ['dist/db/migrations/*.js'],
   ssl: process.env.DATABASE_USE_SSL

--- a/server/repositories/entities/answerGroup.ts
+++ b/server/repositories/entities/answerGroup.ts
@@ -16,6 +16,6 @@ export default class AnswerGroup {
   @OneToMany('Answer', 'answerSchemaGroup', { eager: true })
   answers: Array<Answer>
 
-  @OneToMany('Answer', 'questionSchemaUuid', { eager: false })
+  @OneToMany('Question', 'questionSchemaUuid', { eager: false })
   questions: Promise<Array<Question>>
 }

--- a/server/repositories/entities/assessmentSchema.ts
+++ b/server/repositories/entities/assessmentSchema.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
+
+@Entity({ name: 'assessment_schema' })
+export default class AssessmentSchema {
+  @PrimaryGeneratedColumn({ name: 'assessment_schema_id' })
+  assessmentSchemaId: number
+
+  @Column({ name: 'assessment_schema_uuid', type: 'uuid' })
+  assessmentSchemaUuid: string
+
+  @Column({ name: 'assessment_schema_code' })
+  assessmentSchemaCode: string
+
+  @Column({ name: 'oasys_assessment_type' })
+  oasysAssessmentType: string
+
+  @Column({ name: 'oasys_create_assessment_at' })
+  oasysCreateAssessmentAt: string
+
+  @Column({ name: 'assessment_name' })
+  assessmentName: string
+}

--- a/server/repositories/entities/assessmentSchemaGroup.ts
+++ b/server/repositories/entities/assessmentSchemaGroup.ts
@@ -1,0 +1,17 @@
+import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import type AssessmentSchema from './assessmentSchema'
+import type Grouping from './grouping'
+
+@Entity({ name: 'assessment_schema_groups' })
+export default class AssessmentSchemaGroups {
+  @PrimaryGeneratedColumn({ name: 'assessment_schema_group_id' })
+  assessmentSchemaGroupId: number
+
+  @ManyToOne('AssessmentSchema', 'assessmentSchemaUuid', { eager: true })
+  @JoinColumn({ name: 'assessment_schema_uuid', referencedColumnName: 'assessmentSchemaUuid' })
+  assessmentSchema: AssessmentSchema
+
+  @ManyToOne('Grouping', 'groupUuid', { eager: true })
+  @JoinColumn({ name: 'group_uuid', referencedColumnName: 'groupUuid' })
+  group: Grouping
+}

--- a/server/repositories/entities/question.ts
+++ b/server/repositories/entities/question.ts
@@ -1,5 +1,6 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
 import type AnswerGroup from './answerGroup'
+import type QuestionDependency from './questionDependency'
 
 @Entity({ name: 'question_schema' })
 export default class Question {
@@ -39,4 +40,10 @@ export default class Question {
   @ManyToOne('AnswerGroup', 'questions', { eager: true })
   @JoinColumn({ name: 'answer_schema_group_uuid', referencedColumnName: 'answerSchemaGroupUuid' })
   answerSchema: AnswerGroup | null
+
+  @OneToMany('QuestionDependency', 'subjectQuestion', { eager: true })
+  subjects: Array<QuestionDependency> | null
+
+  @OneToMany('QuestionDependency', 'triggerQuestion', { eager: true })
+  targets: Array<QuestionDependency> | null
 }

--- a/server/repositories/entities/questionDependency.ts
+++ b/server/repositories/entities/questionDependency.ts
@@ -1,0 +1,28 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import type Question from './question'
+
+@Entity({ name: 'question_dependency' })
+export default class QuestionDependency {
+  @PrimaryGeneratedColumn({ name: 'dependency_id' })
+  dependencyId: number
+
+  @ManyToOne('Question', 'question', { eager: false })
+  @JoinColumn({ name: 'subject_question_uuid', referencedColumnName: 'questionSchemaUuid' })
+  subjectQuestion: Promise<Question>
+
+  @ManyToOne('Question', 'question', { eager: false })
+  @JoinColumn({ name: 'trigger_question_uuid', referencedColumnName: 'questionSchemaUuid' })
+  triggerQuestion: Promise<Question>
+
+  @Column({ name: 'trigger_answer_value' })
+  triggerAnswerValue: string
+
+  @Column({ name: 'dependency_start' })
+  startDate: Date = null
+
+  @Column({ name: 'dependency_end' })
+  endDate: Date = null
+
+  @Column({ name: 'display_inline' })
+  displayInline: boolean
+}

--- a/server/views/partials/questionEditor.njk
+++ b/server/views/partials/questionEditor.njk
@@ -83,6 +83,22 @@
       }
     ]
   }) }}
+  {% if question.targets.length %}
+  <p class="govuk-label--s">This question is the target of:</p>
+  <ul class="govuk-list">
+  {% for target in question.targets %}
+    <li><a href="#" class="govuk-link">Dependency {{target.dependencyId}}</a></li>
+  {% endfor %}
+  </ul>
+  {% endif %}
+  {% if question.subjects.length %}
+  <p class="govuk-label--s">This question is the subject of:</p>
+  <ul class="govuk-list">
+  {% for subject in question.subjects %}
+    <li><a href="#" class="govuk-link">Dependency {{subject.dependencyId}}</a></li>
+  {% endfor %}
+  </ul>
+  {% endif %}
   {{ govukButton({
     text: "Update question",
     type: "submit"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "./dist",


### PR DESCRIPTION
This PR add's support for top level assessment entities in the management tool, along with initial support for visualising conditional question dependencies.

**note:** this PR depends on the migrations for `hmpps-assessments-api` being up to date in Dev