### PR TITLE
Remove oasys question code from question schema

### DIFF
--- a/db/migrations/1623852472151-ReferenceData.ts
+++ b/db/migrations/1623852472151-ReferenceData.ts
@@ -26,8 +26,7 @@ export class ReferenceData1623852472151 implements MigrationInterface {
             CREATE TABLE IF NOT EXISTS question_schema(
             question_schema_id SERIAL PRIMARY KEY,
             question_schema_uuid UUID NOT NULL unique,
-            question_code TEXT NOT NULL,
-            oasys_question_code TEXT,
+            question_code TEXT NOT NULL,            
             external_source TEXT,
             question_start TIMESTAMP NOT NULL,
             question_end TIMESTAMP,

--- a/server/repositories/entities/question.ts
+++ b/server/repositories/entities/question.ts
@@ -13,9 +13,6 @@ export default class Question {
   @Column({ name: 'question_code' })
   questionCode: string
 
-  @Column({ name: 'oasys_question_code' })
-  oasysQuestionCode: string
-
   @Column({ name: 'external_source' })
   externalSource: string
 

--- a/server/routes/dto/questionResponse.ts
+++ b/server/routes/dto/questionResponse.ts
@@ -11,7 +11,6 @@ type QuestionResponse = {
   contentUuid: string
   displayOrder: number
   questionCode: string
-  oasysQuestionCode: string
   answers: MultipleChoiceOptions
   mandatory: boolean
   readOnly: boolean
@@ -25,7 +24,6 @@ export function questionResponseFrom(question: Question, questionGroup: Question
     contentUuid: question.questionSchemaUuid,
     displayOrder: questionGroup.displayOrder,
     questionCode: question.questionCode,
-    oasysQuestionCode: question.oasysQuestionCode,
     answers: question.answerSchema?.answers.map(({ value, text }): MultipleChoiceOption => ({ value, text })),
     mandatory: questionGroup.mandatory,
     readOnly: questionGroup.readOnly,

--- a/server/routes/questionRouter.ts
+++ b/server/routes/questionRouter.ts
@@ -80,7 +80,6 @@ export default function questionRouter(
           { name: 'Help Text', value: question.questionHelpText },
           { name: 'Answer Type', value: question.answerType },
           { name: 'Question Code', value: question.questionCode },
-          { name: 'OASys Code', value: question.oasysQuestionCode },
           { name: 'Reference Data', value: question.referenceDataCategory },
           { name: 'Mandatory', value: questionGroupEntity.mandatory },
           { name: 'Readonly', value: questionGroupEntity.readOnly },
@@ -141,7 +140,6 @@ export default function questionRouter(
           questionSchemaUuid,
           answerType,
           questionCode,
-          oasysQuestionCode,
           answerSchema,
           subjects,
           targets,
@@ -154,7 +152,6 @@ export default function questionRouter(
             contentUuid: questionSchemaUuid,
             displayOrder: additionalInformation?.displayOrder,
             questionCode,
-            oasysQuestionCode,
             answerGroup: answerSchema?.answerSchemaGroupUuid || null,
             answers: answerSchema?.answers.map(({ value, text }) => ({ value, text })),
             mandatory: additionalInformation?.mandatory,
@@ -274,7 +271,6 @@ export default function questionRouter(
         question.answerSchema = updatedQuestion.answerGroup
           ? await answerGroupRepository.findOne({ where: { answerSchemaGroupUuid: updatedQuestion.answerGroup } })
           : null
-        question.oasysQuestionCode = updatedQuestion.oasysQuestionCode
         question.referenceDataCategory = updatedQuestion.referenceDataCategory
 
         await entityManager.save(question)

--- a/server/views/partials/questionEditor.njk
+++ b/server/views/partials/questionEditor.njk
@@ -49,7 +49,7 @@
       {% endfor %}
     </select>
   </div>
-  {{ govukInput({
+  {# {{ govukInput({
     label: {
       text: "OASys code",
       classes: "govuk-label--s"
@@ -57,7 +57,7 @@
     id:  question.contentUuid + "oasys-question-code",
     name: "oasys-question-code",
     value: question.oasysQuestionCode
-  }) }}
+  }) }} #}
   {{ govukInput({
     label: {
       text: "Reference data code",


### PR DESCRIPTION
In response to [PR 192](https://github.com/ministryofjustice/hmpps-assessments-api/pull/192) on the `hmpps-assessments-api` - this PR removes the unused OASys question code field