### PR TITLE
Add OASys mappings

### DIFF
--- a/server/repositories/db.ts
+++ b/server/repositories/db.ts
@@ -9,6 +9,7 @@ import AnswerGroup from './entities/answerGroup'
 import QuestionDependency from './entities/questionDependency'
 import AssessmentSchema from './entities/assessmentSchema'
 import AssessmentSchemaGroups from './entities/assessmentSchemaGroup'
+import QuestionMapping from './entities/questionMapping'
 
 type ConnectionResult = [Error?, Connection?]
 
@@ -23,6 +24,7 @@ const connectionOptions: ConnectionOptions = {
   entities: [
     Grouping,
     QuestionGroup,
+    QuestionMapping,
     Question,
     Answer,
     AnswerGroup,

--- a/server/repositories/entities/question.ts
+++ b/server/repositories/entities/question.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
 import type AnswerGroup from './answerGroup'
 import type QuestionDependency from './questionDependency'
+import type QuestionMapping from './questionMapping'
 
 @Entity({ name: 'question_schema' })
 export default class Question {
@@ -43,4 +44,7 @@ export default class Question {
 
   @OneToMany('QuestionDependency', 'triggerQuestion', { eager: true })
   targets: Array<QuestionDependency> | null
+
+  @OneToMany('QuestionMapping', 'questionSchemaUuid', { eager: true })
+  mappings: Array<QuestionMapping> | null
 }

--- a/server/repositories/entities/questionMapping.ts
+++ b/server/repositories/entities/questionMapping.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import type Question from './question'
+
+@Entity({ name: 'oasys_question_mapping' })
+export default class QuestionMapping {
+  @PrimaryGeneratedColumn({ name: 'mapping_id' })
+  mappingId: number
+
+  @Column({ name: 'mapping_uuid', type: 'uuid' })
+  mappingUuid: string
+
+  @Column({ name: 'ref_section_code' })
+  sectionCode: string
+
+  @Column({ name: 'ref_question_code' })
+  questionCode: string
+
+  @Column({ name: 'logical_page' })
+  logicalPage: number
+
+  @Column({ name: 'fixed_field' })
+  fixedField: boolean
+
+  @ManyToOne('Question', 'questionSchemaUuid', { eager: false })
+  @JoinColumn({ name: 'question_schema_uuid', referencedColumnName: 'questionSchemaUuid' })
+  questionSchemaUuid: Question
+}

--- a/server/routes/questionRouter.ts
+++ b/server/routes/questionRouter.ts
@@ -141,6 +141,7 @@ export default function questionRouter(
           answerType,
           questionCode,
           answerSchema,
+          mappings,
           subjects,
           targets,
         }) => {
@@ -156,6 +157,7 @@ export default function questionRouter(
             answers: answerSchema?.answers.map(({ value, text }) => ({ value, text })),
             mandatory: additionalInformation?.mandatory,
             readOnly: additionalInformation?.readOnly,
+            mappings,
             subjects,
             targets,
           }

--- a/server/views/partials/questionEditor.njk
+++ b/server/views/partials/questionEditor.njk
@@ -49,15 +49,6 @@
       {% endfor %}
     </select>
   </div>
-  {# {{ govukInput({
-    label: {
-      text: "OASys code",
-      classes: "govuk-label--s"
-    },
-    id:  question.contentUuid + "oasys-question-code",
-    name: "oasys-question-code",
-    value: question.oasysQuestionCode
-  }) }} #}
   {{ govukInput({
     label: {
       text: "Reference data code",
@@ -83,6 +74,14 @@
       }
     ]
   }) }}
+  {% if question.mappings.length %}
+  <p class="govuk-label--s">This question is the mapped to the following OASys fields:</p>
+  <ul class="govuk-list">
+  {% for mapping in question.mappings %}
+    <li><a href="#" class="govuk-link">{{mapping.sectionCode}}:{{mapping.questionCode}}</a></li>
+  {% endfor %}
+  </ul>
+  {% endif %}
   {% if question.targets.length %}
   <p class="govuk-label--s">This question is the target of:</p>
   <ul class="govuk-list">


### PR DESCRIPTION
This PR adds support to display the OASys question mappings attached to a question schema, displaying them read-only in the format `sectionCode:questionCode` to assist in visualising the relationship